### PR TITLE
Make it easier to override default settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ boot_out.txt
 System Volume Information/*
 .vscode/
 .idea/
+/user/
+/user.py

--- a/code.py
+++ b/code.py
@@ -5,18 +5,16 @@ It enables you to more easily create complex layouts and has other advanced
 features, including double-tap support.
 """
 
-from apps.home import HomeApp
 from utils.app_pad import AppPad
 from utils.commands import AppSwitchException
-from utils.constants import OS_MAC, OS_SETTING, PREVIOUS_APP_SETTING
 
-app_settings = {
-    OS_SETTING: OS_MAC,
-    PREVIOUS_APP_SETTING: [],
-}
+try:
+    from user.settings import DEFAULT_APP
+except ImportError:
+    from default_settings import DEFAULT_APP
 
 app_pad = AppPad()
-current_app = HomeApp(app_pad, app_settings)
+current_app = DEFAULT_APP(app_pad)
 
 while True:
     try:

--- a/code.py
+++ b/code.py
@@ -9,7 +9,7 @@ from utils.app_pad import AppPad
 from utils.commands import AppSwitchException
 
 try:
-    from user.settings import DEFAULT_APP
+    from user import DEFAULT_APP
 except ImportError:
     from default_settings import DEFAULT_APP
 

--- a/default_settings.py
+++ b/default_settings.py
@@ -1,0 +1,9 @@
+from apps.home import HomeApp
+from utils.constants import OS_SETTING, OS_WINDOWS, PREVIOUS_APP_SETTING
+
+app_settings = {
+    OS_SETTING: OS_WINDOWS,
+    PREVIOUS_APP_SETTING: [],
+}
+
+DEFAULT_APP = lambda app_pad: HomeApp(app_pad, app_settings)


### PR DESCRIPTION
### Overview

This PR makes it easier for others to use this code by providing a way to load a user-specific configuration without changing the versioned code. `code.py` will first attempt to import a `DEFAULT_APP` value from a `user` module. If this import fails, it will import `DEFAULT_APP` from `default_settings`.

Users can create a `user.py` file containing their `DEFAULT_APP`. Or they can create a `user` module containing additional apps and add `DEFAULT_APP` in `user.__init__`.