### PR TITLE
Handle exceptions raised while a key is pressed

### DIFF
--- a/code.py
+++ b/code.py
@@ -18,9 +18,22 @@ app_settings = {
 app_pad = AppPad()
 current_app = HomeApp(app_pad, app_settings)
 
-while True:
-    try:
-        print(f"Current App = {current_app}")
-        current_app.run()
-    except AppSwitchException as err:
-        current_app = err.app
+try:
+    while True:
+        try:
+            print(f"Current App = {current_app}")
+            current_app.run()
+        except AppSwitchException as err:
+            current_app = err.app
+except Exception as e:
+    print("Exception in event_stream, importing keyboard and releasing all keys.")
+
+    from adafruit_hid.keyboard import Keyboard
+    from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
+    from usb_hid import devices
+
+    keyboard = Keyboard(devices)
+    keyboard_layout = KeyboardLayoutUS(keyboard)
+    keyboard.release_all()
+
+    raise e

--- a/code.py
+++ b/code.py
@@ -29,11 +29,7 @@ except Exception as e:
     print("Exception in event_stream, importing keyboard and releasing all keys.")
 
     from adafruit_hid.keyboard import Keyboard
-    from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
     from usb_hid import devices
 
-    keyboard = Keyboard(devices)
-    keyboard_layout = KeyboardLayoutUS(keyboard)
-    keyboard.release_all()
-
+    Keyboard(devices).release_all()
     raise e


### PR DESCRIPTION
In a situation where the MacroPad is sending a command to the host computer to press a key, and the MacroPad encounters an exception, the key will remain pressed on the host computer with no way to release it. This has happened to me most annoyingly with keys like windows, shift, ctrl, etc. This causes an obvious disruption on the host computer. 

This PR addresses this issue by lifting all keys when any exception is caught inside of `code.py`.

