### PR TITLE
Process events from serial connection

### DIFF
--- a/apps/home.py
+++ b/apps/home.py
@@ -95,6 +95,7 @@ class HomeApp(KeyApp):
                 OS_LINUX: COLOR_LINUX,
             },
             text_template="[ {value} ]",
+            text_mapping={OS_LINUX: "LIN", OS_MAC: "MAC", OS_WINDOWS: "WIN"},
         )
 
         numpad_app = NumpadApp(app_pad, settings)

--- a/boot.py
+++ b/boot.py
@@ -1,0 +1,3 @@
+import usb_cdc
+
+usb_cdc.enable(console=True, data=True)

--- a/utils/apps/base.py
+++ b/utils/apps/base.py
@@ -22,6 +22,7 @@ from utils.app_pad import (
     EncoderButtonEvent,
     EncoderEvent,
     KeyEvent,
+    SerialEvent,
 )
 from utils.constants import DISPLAY_HEIGHT, DISPLAY_WIDTH
 
@@ -194,6 +195,8 @@ class BaseApp:
             self.key_event(event)
         elif isinstance(event, DoubleTapEvent):
             self.double_tap_event(event)
+        elif isinstance(event, SerialEvent):
+            self.serial_event(event)
 
     def encoder_event(self, event: EncoderEvent):
         """Process an encoder event.
@@ -225,5 +228,14 @@ class BaseApp:
 
         Args:
             event (DoubleTapEvent): An event triggered by double-tapping a key
+        """
+        pass
+
+    def serial_event(self, event: SerialEvent):
+        """Process a message from the serial port.
+
+        Args:
+            event (SerialEvent): An event triggered by a message over the
+                serial port
         """
         pass

--- a/utils/apps/base.py
+++ b/utils/apps/base.py
@@ -131,6 +131,8 @@ class BaseApp:
         else:
             self.settings = settings
 
+        self.settings.register_app(self)
+
     def run(self):
         """The main run loop for the app.
 

--- a/utils/apps/key.py
+++ b/utils/apps/key.py
@@ -135,7 +135,7 @@ class KeyAppSettings(BaseSettings):
         return 0x000000
 
     def serial_event(self, app: "KeyApp", event: SerialEvent):
-        if event.message["event"] == EVENT_CONNECT:
+        if event.message.get("event") == EVENT_CONNECT:
             self.host_os = event.message[OS_SETTING]
             app.on_focus()
 

--- a/utils/apps/key.py
+++ b/utils/apps/key.py
@@ -20,6 +20,7 @@ from utils.app_pad import (
     EncoderButtonEvent,
     EncoderEvent,
     KeyEvent,
+    SerialEvent,
 )
 from utils.apps.base import BaseApp
 from utils.commands import Command
@@ -272,7 +273,10 @@ class KeyApp(BaseApp):
         self.settings.pixels_disabled = True
 
     def process_event(
-        self, event: Union[DoubleTapEvent, EncoderButtonEvent, EncoderEvent, KeyEvent]
+        self,
+        event: Union[
+            DoubleTapEvent, EncoderButtonEvent, EncoderEvent, KeyEvent, SerialEvent
+        ],
     ):
         if self.settings.pixels_disabled:
             self.pixels_on_focus()
@@ -359,6 +363,10 @@ class KeyApp(BaseApp):
             key.double_tap()
         else:
             key.double_tap_release()
+
+    def serial_event(self, event: SerialEvent):
+        print("received serial event", event.message)
+        self.settings.pixels_disabled = not self.settings.pixels_disabled
 
 
 class Key:

--- a/utils/commands.py
+++ b/utils/commands.py
@@ -336,7 +336,7 @@ class SwitchAppCommand(Command):
         Args:
             app (BaseApp): The current app
         """
-        self.switch_app(self.app, app)
+        self.switch_app(app, self.app)
 
     @staticmethod
     def switch_app(current_app, new_app):

--- a/utils/commands.py
+++ b/utils/commands.py
@@ -9,6 +9,11 @@ is released.
 
 import time
 
+try:
+    from typing import List
+except ImportError:
+    pass
+
 # Expose these libraries to those that use commands
 from adafruit_hid.consumer_control_code import ConsumerControlCode
 from adafruit_hid.keycode import Keycode  # REQUIRED if using Keycode.* values
@@ -331,13 +336,20 @@ class SwitchAppCommand(Command):
         Args:
             app (BaseApp): The current app
         """
+        self.switch_app(self.app, app)
+
+    @staticmethod
+    def switch_app(current_app, new_app):
+        if current_app is new_app:
+            return
+
         try:
-            app_stack = self.app.settings[PREVIOUS_APP_SETTING]
+            app_stack = current_app.settings[PREVIOUS_APP_SETTING]
         except KeyError:
             app_stack = []
-            self.app.settings[PREVIOUS_APP_SETTING] = app_stack
-        app_stack.append(app)
-        raise AppSwitchException(self.app)
+            current_app.settings[PREVIOUS_APP_SETTING] = app_stack
+        app_stack.append(current_app)
+        raise AppSwitchException(new_app)
 
 
 class PreviousAppCommand(Command):
@@ -353,9 +365,12 @@ class PreviousAppCommand(Command):
             app (BaseApp): The current app
 
         """
-        app_stack = app.settings.get(PREVIOUS_APP_SETTING, [])
-        previous_app = app_stack.pop()
-        if previous_app is not None:
+        app_stack: List[BaseApp] = app.settings.get(PREVIOUS_APP_SETTING, [])
+        try:
+            previous_app = app_stack.pop()
+        except IndexError:
+            pass
+        else:
             raise AppSwitchException(previous_app)
 
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -14,8 +14,8 @@ PREVIOUS_APP_SETTING = "previous_app"
 
 # The setting name and options for the OS setting
 OS_SETTING = "host_os"
-OS_MAC = "MAC"
-OS_WINDOWS = "WIN"
+OS_MAC = "darwin"
+OS_WINDOWS = "win32"
 OS_LINUX = "LIN"
 
 # Setting name for the pixels disabled setting
@@ -25,6 +25,11 @@ ONE_MINUTE = 60
 
 # Timer ID for the disabled pixels timer
 TIMER_DISABLE_PIXELS = "disable pixels timer"
+
+# Event types
+EVENT_CONNECT = "connect"
+EVENT_SYNC_TIME = "sync_time"
+EVENT_UPDATE_ACTIVE_WINDOW = "update_active_window"
 
 # Defines color names for the color scheme for the Macropad. You can use these
 # color names to refer to colors defined in the default color scheme defined

--- a/utils/serial.py
+++ b/utils/serial.py
@@ -1,0 +1,34 @@
+import json
+
+import supervisor
+import usb_cdc
+
+# from adafruit_hid.keyboard import Keyboard
+# from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
+# from usb_hid import devices
+
+# keyboard = Keyboard(devices)
+# keyboard_layout = KeyboardLayoutUS(keyboard)
+
+
+def get_serial_data():
+    if not usb_cdc.data:
+        return None
+
+    data = None
+    if usb_cdc.data.in_waiting > 0:
+        data = usb_cdc.data.readline()
+
+    if not data:
+        return None
+
+    if len(data) > 0:
+        usb_cdc.data.reset_input_buffer()
+        return json.loads(data)
+
+    return None
+
+
+def clear_serial():
+    while supervisor.runtime.serial_bytes_available:
+        input()

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,5 +1,5 @@
 try:
-    from typing import TYPE_CHECKING, Any, Dict
+    from typing import TYPE_CHECKING, Any, Dict, Optional
 except ImportError:
     TYPE_CHECKING = False
 
@@ -41,3 +41,6 @@ class BaseSettings:
 
     def register_app(self, app: BaseApp):
         self.registered_apps[app.name] = app
+
+    def get_app(self, name: str) -> Optional[BaseApp]:
+        return self.registered_apps.get(name, None)

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,16 +1,21 @@
 try:
-    from typing import Any, Dict
+    from typing import TYPE_CHECKING, Any, Dict
 except ImportError:
-    pass
+    TYPE_CHECKING = False
 
 from utils.constants import EMPTY_VALUE
+
+if TYPE_CHECKING:
+    from utils.apps.base import BaseApp
 
 
 class BaseSettings:
     additional_settings: Dict[str, Any]
+    registered_apps: Dict[str, BaseApp]
 
     def __init__(self, **kwargs):
         self.additional_settings = {}
+        self.registered_apps = {}
         for key, value in kwargs.items():
             self[key] = value
 
@@ -33,3 +38,6 @@ class BaseSettings:
             if default is EMPTY_VALUE:
                 raise err
             return default
+
+    def register_app(self, app: BaseApp):
+        self.registered_apps[app.name] = app


### PR DESCRIPTION
This PR adds basic support for processing events over a serial connection. There is [a helper app in a separate repo](https://github.com/kbaskett248/adafruit-macropad-helper) that sends these events. This is heavily inspired by https://github.com/kbaskett248/adafruit_macropad/pull/5. 

So far, the helper has only been tested on windows. I'll give it a try on Mac soon.